### PR TITLE
Remove through-cargo rename of inner proc-macro crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,7 @@ repository = "https://github.com/danielhenrymantilla/mini_paste"
 
 license = "Zlib"
 
-[dependencies.proc_macro]
-package = "mini_paste-proc_macro"
+[dependencies.mini_paste-proc_macro]
 path = "src/proc_macro"
 version = "0.1.10"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,10 +4,10 @@
     doc(include = "../README.md"),
 )]
 
-extern crate proc_macro;
+extern crate mini_paste_proc_macro;
 
 /** Not part of the public API **/ #[doc(hidden)]
-pub use ::proc_macro::{
+pub use ::mini_paste_proc_macro::{
     item as __item__,
     __expr_hack__,
 };


### PR DESCRIPTION
# Problem

When cross-compiling and depending on a Cargo-renamed pure proc-macro crate a rustc bug can sometimes be triggered which errors in unresolved imports.

In the case of `::mini_paste`, the bug amounted to the following errors:

```
error[E0432]: unresolved imports `proc_macro::item`, `proc_macro::__expr_hack__`
   |
11 |     item as __item__,
   |     ----^^^^^^^^^^^^
   |     |
   |     no `item` in the root
   |     help: a similar name exists in the module: `iter`
12 |     __expr_hack__,
   |     ^^^^^^^^^^^^^ no `__expr_hack__` in the root

error: aborting due to previous error

For more information about this error, try `rustc --explain E0432`.
error: could not compile `mini_paste`
```


# Solution

Undo the renaming at the `Cargo.toml` layer and instead use the full name in `src/lib.rs`. This is unfortunate, but the change is at least contained entirely within the crate.

I've confirmed with a Cargo patch that undoing these renames avoids triggering the rustc bug when cross-compiling.